### PR TITLE
Add github.com prefix to systray_unix.go and systray_menu_unix.go.

### DIFF
--- a/systray_menu_unix.go
+++ b/systray_menu_unix.go
@@ -9,7 +9,7 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/prop"
 
-	"energye/systray/internal/generated/menu"
+	"github.com/energye/systray/internal/generated/menu"
 )
 
 // SetIcon sets the icon of a menu item.

--- a/systray_unix.go
+++ b/systray_unix.go
@@ -20,8 +20,8 @@ import (
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/godbus/dbus/v5/prop"
 
-	"energye/systray/internal/generated/menu"
-	"energye/systray/internal/generated/notifier"
+	"github.com/energye/systray/internal/generated/menu"
+	"github.com/energye/systray/internal/generated/notifier"
 	dbus "github.com/godbus/dbus/v5"
 )
 


### PR DESCRIPTION
I found that in your `systray_unix.go` and `systray_menu_unix.go` files, you didn't use github.com/energye/systray in `import` but energye/systray, maybe you forgot to change it after modifying the go.mod file, I'll give it a I've added it. #1