### PR TITLE
Fix incompatible `func` type in `README.md` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ func onReady() {
 	systray.SetIcon(icon.Data)
 	systray.SetTitle("Awesome App")
 	systray.SetTooltip("Pretty awesome超级棒")
-	systray.SetOnClick(func() {
+	systray.SetOnClick(func(menu systray.IMenu) {
 		fmt.Println("SetOnClick")
 	})
-	systray.SetOnDClick(func() {
+	systray.SetOnDClick(func(menu systray.IMenu) {
 		fmt.Println("SetOnDClick")
 	})
 	systray.SetOnRClick(func(menu systray.IMenu) {


### PR DESCRIPTION
I was getting:
```
Cannot use 'func() { fmt. Println("SetOnDClick") }' (type func()) as the type func(menu IMenu)
```