### PR TITLE
Fix/icon handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ systray is a cross-platform Go library to place an icon and menu in the notifica
 This repository is a fork of [getlantern/systray](https://github.com/getlantern/systray)
 removing the GTK dependency and support for legacy linux system tray.
 
+## Modified:
+- Fix Windows GDI objects leak.
+- Disable icon cache.
+- Systray icon handling in memory. Not in files.
+
 ## Features
 
 * Supported on Windows, macOS, Linux and many BSD systems
@@ -16,8 +21,8 @@ removing the GTK dependency and support for legacy linux system tray.
 ```go
 package main
 
-import "github.com/energye/systray"
-import "github.com/energye/systray/icon"
+import "github.com/lutischan-ferenc/systray"
+import "github.com/lutischan-ferenc/systray/icon"
 
 func main() {
 	systray.Run(onReady, onExit)
@@ -111,12 +116,12 @@ If bundling manually, you may want to add one or both of the following to your I
 
 ```xml
 	<!-- avoid having a blurry icon and text -->
-	<key>NSHighResolutionCapable</key>
-	<string>True</string>
+<key>NSHighResolutionCapable</key>
+<string>True</string>
 
-	<!-- avoid showing the app on the Dock -->
-	<key>LSUIElement</key>
-	<string>1</string>
+        <!-- avoid showing the app on the Dock -->
+<key>LSUIElement</key>
+<string>1</string>
 ```
 
 Consult the [Official Apple Documentation here](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW1).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/energye/systray
+module github.com/lutischan-ferenc/systray
 
 go 1.13
 

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -250,24 +250,23 @@ func (t *winTray) isReady() bool {
 // Loads an image from file and shows it in tray.
 // Shell_NotifyIcon: https://msdn.microsoft.com/en-us/library/windows/desktop/bb762159(v=vs.85).aspx
 func (t *winTray) setIcon(src string) error {
-	if !wt.isReady() {
-		return ErrTrayNotReadyYet
-	}
-
-	const NIF_ICON = 0x00000002
-
-	h, err := t.loadIconFrom(src)
-	if err != nil {
-		return err
-	}
-
-	t.muNID.Lock()
-	defer t.muNID.Unlock()
-	t.nid.Icon = h
-	t.nid.Flags |= NIF_ICON
-	t.nid.Size = uint32(unsafe.Sizeof(*t.nid))
-
-	return t.nid.modify()
+    if !wt.isReady() {
+        return ErrTrayNotReadyYet
+    }
+    const NIF_ICON = 0x00000002
+    h, err := t.loadIconFrom(src)
+    if err != nil {
+        return err
+    }
+    t.muNID.Lock()
+    defer t.muNID.Unlock()
+    if t.nid.Icon != 0 {
+        pDestroyIcon.Call(uintptr(t.nid.Icon))
+    }
+    t.nid.Icon = h
+    t.nid.Flags |= NIF_ICON
+    t.nid.Size = uint32(unsafe.Sizeof(*t.nid))
+    return t.nid.modify()
 }
 
 // Sets tooltip on icon.

--- a/systray_windows.go
+++ b/systray_windows.go
@@ -66,7 +66,8 @@ var (
 	pTranslateMessage      = u32.NewProc("TranslateMessage")
 	pUnregisterClass       = u32.NewProc("UnregisterClassW")
 	pUpdateWindow          = u32.NewProc("UpdateWindow")
-
+	pDestroyIcon           = u32.NewProc("DestroyIcon")
+	
 	// ErrTrayNotReadyYet is returned by functions when they are called before the tray has been initialized.
 	ErrTrayNotReadyYet = errors.New("tray not ready yet")
 )


### PR DESCRIPTION
- Fix Windows GDI objects leak.
- Disable icon cache.
- Systray icon handling in memory. Not in files.