### PR TITLE
unix: change ItemIsMenu to false, so the systray.OnClick can work

### DIFF
--- a/systray_unix.go
+++ b/systray_unix.go
@@ -341,7 +341,7 @@ func (*tray) iface() string {
 
 func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 	t.lock.Lock()
-	t.lock.Unlock()
+	defer t.lock.Unlock()
 	return map[string]map[string]*prop.Prop{
 		"org.kde.StatusNotifierItem": {
 			"Status": {
@@ -387,7 +387,7 @@ func (t *tray) createPropSpec() map[string]map[string]*prop.Prop {
 				Callback: nil,
 			},
 			"ItemIsMenu": {
-				Value:    true,
+				Value:    false,
 				Writable: false,
 				Emit:     prop.EmitTrue,
 				Callback: nil,


### PR DESCRIPTION
https://www.freedesktop.org/wiki/Specifications/StatusNotifierItem/StatusNotifierItem/

> org.freedesktop.StatusNotifierItem.ItemIsMenu
> BOOL: The item only support the context menu, the visualization should prefer showing the menu or sending ContextMenu() instead of Activate()

ItemIsMenu should be false (or better, set this propery by whether register systray.SetOnClick )
